### PR TITLE
Add eslint-config-typescript

### DIFF
--- a/packages/eslint-config-typescript/README.md
+++ b/packages/eslint-config-typescript/README.md
@@ -5,13 +5,13 @@
 ## Installation
 
 ```bash
-yarn add @guardian/eslint-config-typescript
+yarn add -D @guardian/eslint-config-typescript
 ```
 
 or
 
 ```bash
-npm install @guardian/eslint-config-typescript
+npm install --save-dev @guardian/eslint-config-typescript
 ```
 
 ## Usage

--- a/packages/eslint-config-typescript/README.md
+++ b/packages/eslint-config-typescript/README.md
@@ -1,0 +1,24 @@
+# `@guardian/eslint-config-typescript`
+
+> ESLint config for Guardian TypeScript projects.
+
+## Installation
+
+```bash
+yarn add @guardian/eslint-config-typescript
+```
+
+or
+
+```bash
+npm install @guardian/eslint-config-typescript
+```
+
+## Usage
+
+```js
+// ESLint configuration file
+{
+    "extends": "@guardian/eslint-config-typescript"
+}
+```

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -21,9 +21,9 @@ module.exports = {
 		not direct or inhibit what can be done with code.
 		*/
 
-		// use `string[]` instead of `Array<string>`
-		// https://basarat.gitbook.io/typescript/styleguide#array
-		'@typescript-eslint/array-type': ['error', 'generic'],
+		// use `string[]` for simple arrays, `Array<string>` for complex ones
+		// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md#array-simple
+		'@typescript-eslint/array-type': ['error', 'array-simple'],
 
 		// use `Record<string, unknown>` instead of `{ [key: string]: unknown }`
 		'@typescript-eslint/consistent-indexed-object-style': [

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -61,6 +61,7 @@ module.exports = {
 		// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.md
 		'@typescript-eslint/prefer-reduce-type-parameter': 2,
 
+		// use String#startsWith or String#endsWith instead of String#indexOf et al
 		'@typescript-eslint/prefer-string-starts-ends-with': 2,
 
 		// use `@ts-expect-error` instead of `@ts-ignore`

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -72,6 +72,30 @@ module.exports = {
 		NOT FIXABLE BUT USEFUL
 		*/
 
+		// Enforce TypeScript naming conventions
+		// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
+		'@typescript-eslint/naming-convention': [
+			'error',
+
+			// functions are 'camelCase', React components are 'PascalCase'
+			{
+				selector: 'function',
+				format: ['camelCase', 'PascalCase'],
+			},
+
+			// variables are 'camelCase' or 'UPPER_CASE', React components are 'PascalCase',
+			{
+				selector: 'variable',
+				format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+			},
+
+			// types are 'PascalCase'
+			{
+				selector: ['typeLike', 'enumMember'],
+				format: ['PascalCase'],
+			},
+		],
+
 		// use `foo ?? 'a string'` instead of `foo !== null && foo !== undefined ? foo : 'a string'`
 		'@typescript-eslint/prefer-nullish-coalescing': 2,
 

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -1,0 +1,17 @@
+module.exports = {
+	parser: '@typescript-eslint/parser',
+	parserOptions: {
+		ecmaVersion: 'es2020',
+		project: './tsconfig.json',
+	},
+	plugins: ['@typescript-eslint'],
+	extends: [
+		'@guardian/eslint-config',
+		'plugin:@typescript-eslint/recommended',
+		'plugin:import/typescript',
+		'prettier/@typescript-eslint',
+	],
+	settings: {
+		'import/extensions': ['.ts', '.tsx'],
+	},
+};

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -77,22 +77,18 @@ module.exports = {
 		'@typescript-eslint/naming-convention': [
 			'error',
 
-			// functions are 'camelCase', React components are 'PascalCase'
-			{
-				selector: 'function',
-				format: ['camelCase', 'PascalCase'],
-			},
-
-			// variables are 'camelCase' or 'UPPER_CASE', React components are 'PascalCase',
-			{
-				selector: 'variable',
-				format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
-			},
-
 			// types are 'PascalCase'
 			{
 				selector: ['typeLike', 'enumMember'],
 				format: ['PascalCase'],
+			},
+
+			// booleans are descriptive
+			{
+				selector: 'variable',
+				types: ['boolean'],
+				format: ['PascalCase'],
+				prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
 			},
 		],
 

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -14,4 +14,61 @@ module.exports = {
 	settings: {
 		'import/extensions': ['.ts', '.tsx'],
 	},
+	rules: {
+		/*
+		FIXABLE STYLISTIC CHOICES THAT DIFFER FROM THE DEFAULT
+		The intention is to maximise clarity and consistency,
+		not direct or inhibit what can be done with code.
+		*/
+
+		// use `Array<string>` instead of `string[]`
+		'@typescript-eslint/array-type': ['error', 'generic'],
+
+		// use `Record<string, unknown>` instead of `{ [key: string]: unknown }`
+		'@typescript-eslint/consistent-indexed-object-style': [
+			'error',
+			'record',
+		],
+
+		// be explicit when you only want to import a type:
+		// `import type { Foo } from 'Foo';`
+		'@typescript-eslint/consistent-type-imports': 'prefer',
+
+		// delimit members with semi-colons and require
+		// one at the end to keep diffs simpler
+		'@typescript-eslint/member-delimiter-style': {
+			multiline: {
+				delimiter: 'semi',
+				requireLast: true,
+			},
+			singleline: {
+				delimiter: 'semi',
+				requireLast: true,
+			},
+		},
+
+		// use `(1 + foo.num!) == 2` instead of `1 + foo.num! == 2`
+		'@typescript-eslint/no-confusing-non-null-assertion': 2,
+
+		'@typescript-eslint/no-unnecessary-boolean-literal-compare': 2,
+		'@typescript-eslint/no-unnecessary-condition': 2,
+		'@typescript-eslint/no-unnecessary-qualifier': 2,
+		'@typescript-eslint/no-unnecessary-type-arguments': 2,
+
+		// use `str.includes(value)` instead of `str.indexOf(value) !== -1`
+		'@typescript-eslint/prefer-includes': 2,
+
+		// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.md
+		'@typescript-eslint/prefer-reduce-type-parameter': 2,
+
+		/*
+		NOT FIXABLE BUT USEFUL
+		*/
+
+		// use `foo ?? 'a string'` instead of `foo !== null && foo !== undefined ? foo : 'a string'`
+		'@typescript-eslint/prefer-nullish-coalescing': 2,
+
+		// use `a?.b` instead of `a && a.b`
+		'@typescript-eslint/prefer-optional-chain': 2,
+	},
 };

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -61,6 +61,11 @@ module.exports = {
 		// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.md
 		'@typescript-eslint/prefer-reduce-type-parameter': 2,
 
+		'@typescript-eslint/prefer-string-starts-ends-with': 2,
+
+		// use `@ts-expect-error` instead of `@ts-ignore`
+		'@typescript-eslint/prefer-ts-expect-error': 2,
+
 		/*
 		NOT FIXABLE BUT USEFUL
 		*/
@@ -70,5 +75,8 @@ module.exports = {
 
 		// use `a?.b` instead of `a && a.b`
 		'@typescript-eslint/prefer-optional-chain': 2,
+
+		// requires any function or method that returns a Promise to be marked async
+		'@typescript-eslint/promise-function-async': 2,
 	},
 };

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -7,7 +7,9 @@ module.exports = {
 	plugins: ['@typescript-eslint'],
 	extends: [
 		'@guardian/eslint-config',
+		'plugin:@typescript-eslint/eslint-recommended',
 		'plugin:@typescript-eslint/recommended',
+		'plugin:@typescript-eslint/recommended-requiring-type-checking',
 		'plugin:import/typescript',
 		'prettier/@typescript-eslint',
 	],

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -21,7 +21,8 @@ module.exports = {
 		not direct or inhibit what can be done with code.
 		*/
 
-		// use `Array<string>` instead of `string[]`
+		// use `string[]` instead of `Array<string>`
+		// https://basarat.gitbook.io/typescript/styleguide#array
 		'@typescript-eslint/array-type': ['error', 'generic'],
 
 		// use `Record<string, unknown>` instead of `{ [key: string]: unknown }`

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/eslint-config-typescript",
-  "version": "0.1.2",
+  "version": "0.1.0",
   "description": "ESLint config for Guardian TypeScript projects",
   "homepage": "https://github.com/guardian/configs#readme",
   "license": "MIT",

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@guardian/eslint-config-typescript",
+  "version": "0.1.2",
+  "description": "ESLint config for Guardian TypeScript projects",
+  "homepage": "https://github.com/guardian/configs#readme",
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/guardian/configs.git"
+  },
+  "bugs": {
+    "url": "https://github.com/guardian/configs/issues"
+  },
+  "dependencies": {
+    "@guardian/eslint-config": "^0.1.2"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.0.0",
+    "@typescript-eslint/parser": "^4.0.0",
+    "typescript": "^4.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
## What does this change?

- adds `@guardian/eslint-config-typescript`
- includes some fixable rules and a couple of non-fixable but useful ones

## Why?

try to maximise clarity and consistency in TS codebases