### PR TITLE
feat: add prettier to lint rules

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -8,7 +8,7 @@ module.exports = {
 		'eslint:recommended',
 		'plugin:import/errors',
 		'plugin:import/warnings',
-		'prettier',
+		'plugin:prettier/recommended',
 	],
 	plugins: ['eslint-comments'],
 	rules: {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -16,7 +16,8 @@
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-import": "^2.22.0"
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-prettier": "^3.1.4"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What does this change?

adds prettier as a lint rule

## Why?

previously we just disabled rules which could conflict with prettier. this was an oversight – this corrects that so that prettier formatting is required by eslint rules