### PR TITLE
Add .metals dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.metals/


### PR DESCRIPTION
## What does this change?
Adds `.metals` to the `.gitignore` file.

### Tessting
Added a test folder and file after modifying to check it's correctly ignored.
![image](https://user-images.githubusercontent.com/9122944/101047886-1a645f80-357a-11eb-80c9-24ab5c477104.png)

## Why?
It's not something that will be on everyone's set up, but as more people try using VS Code for Scala development, these folders can sneak into commits and need to be caught during review (e.g. https://github.com/guardian/apps-rendering/pull/1005#discussion_r535194243). Whilst it's not difficult to catch these it might be nice to have it in their as a recommended default.