### PR TITLE
docs: explain the contents of the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Configs
 
-Reusable configs to standardise/share across Guardian codebases.
+Reusable configs to standardise/share across Guardian codebases:
 
 -   [.editorconfig](.editorconfig)
 -   [@guardian/eslint-config](https://www.npmjs.com/package/@guardian/eslint-config)
 -   [@guardian/eslint-config-typescript](https://www.npmjs.com/package/@guardian/eslint-config-typescript)
 -   [@guardian/prettier](https://www.npmjs.com/package/@guardian/prettier)
+
+## Note
+
+This repo is primarily the source code to build the shareable congigs listed above, rather than an example of them.
+
+The one exception to that is the `.editorconfig`, because you can't publish those...

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Reusable configs to standardise/share across Guardian codebases:
 
 ## Note
 
-This repo is primarily the source code to build the shareable congigs listed above, rather than an example of them.
+This repo is primarily the source code to build the shareable configs listed above, rather than an example of them.
 
 The one exception to that is the `.editorconfig`, because you can't publish those...


### PR DESCRIPTION
## What does this change?

tries to explain what is happening in the repo better

## Why?

it wasn't clear before whether this was a set of examples or pure source code (and it's kind of both) ref #9 