### PR TITLE
feat: Allow scala-like unused variables

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -112,5 +112,13 @@ module.exports = {
 
 		// requires any function or method that returns a Promise to be marked async
 		// '@typescript-eslint/promise-function-async': 2,
+		
+		'@typescript-eslint/no-unused-vars': [
+			2, 
+			{ 
+				argsIgnorePattern: '^_$', 
+				varsIgnorePattern: '^_$' 
+			}
+		],
 	},
 };


### PR DESCRIPTION
## What does this change?

Allow variables with a name of exactly `_` to be defined. This is a common pattern in languages such as Scala to denote a throw-away variable.

## Why?

It is really useful when assigning via destructuring, for example:

```typescript
const data = [ "newspaper", 2 ];
const [ _, cost ] = data;

const costPlusVAT = cost * 1.2;
```
