### PR TITLE
Update `.editorconfig` to format yaml files too

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ insert_final_newline = true
 indent_size = 2
 
 # Because `yml`
-[*.yml]
+[*.{yml,yaml}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
This PR changes the target from `[*.yml]` to `[*.{yml,yaml}]` so that yaml files using either extension get formatted.  