### PR TITLE
feat: Move peerDeps to deps and pin them

### DIFF
--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -13,11 +13,11 @@
     "url": "https://github.com/guardian/configs/issues"
   },
   "dependencies": {
-    "@guardian/eslint-config": "^0.5.0"
+    "@guardian/eslint-config": "0.5.0",
+    "@typescript-eslint/eslint-plugin": "4.26.0",
+    "@typescript-eslint/parser": "4.26.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.0.0",
-    "@typescript-eslint/parser": "^4.0.0",
     "typescript": "^4.0.0"
   },
   "publishConfig": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,12 +12,14 @@
   "bugs": {
     "url": "https://github.com/guardian/configs/issues"
   },
+	"dependencies": {
+    "eslint-config-prettier": "8.3.0",
+    "eslint-plugin-eslint-comments": "3.2.0",
+    "eslint-plugin-import": "2.23.4",
+    "eslint-plugin-prettier": "3.4.0"
+	},
   "peerDependencies": {
-    "eslint": "^7.0.0",
-    "eslint-config-prettier": "^8.0.0",
-    "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-prettier": "^3.3.0"
+    "eslint": "^7.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What does this change?

The `@guardian/eslint-config` and `@guardian/eslint-config-typescript` packages define various linting rules. These rules require a few plugins such as `eslint-plugin-eslint-comments`.

Defining these as `peerDependencies` yields quite a complicated install process as you install `@guardian/eslint-config-typescript` then realise also need `eslint-plugin-eslint-comments` etc. even though you're not explicitly using it.

As `eslint-plugin-eslint-comments` etc. are only explicitly used in `@guardian/eslint-config`, it makes sense for them to be installed as direct deps.

Lastly, the version's of these plugins are pinned. This prevents a recent event with `eslint-plugin-import` which changed opinion on the ordering of imports twice in quick succession. By pinning the version, we avoid unwanted surprises - we'll have to explicitly bump the lib.

For example, in `eslint-plugin-import@2.23.2`, `import type`s had to come last. In `eslint-plugin-import@2.23.4` all `import`s should be alphabetical. This is quite a chore as it means the automatic Dependabot PRs fail and one has to manually run `eslint --fix` to resolve the issues. This can be further demonstrated in [these PRs](https://github.com/guardian/cdk/pulls?q=is%3Apr+%22chore%28deps%29%3A+bump+eslint-plugin-import%22).

You could argue that the version bump should be it's own PR. I've rolled it into one so that a single release can be made. Happy to change this if needed.

## Why?

- Using `dependencies` yields an easier installation story
- Using pinned versions removes surprise, as described above