### PR TITLE
feat: Prevent circular dependencies

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -76,5 +76,8 @@ module.exports = {
 				},
 			},
 		],
+
+		// prevent circular dependencies
+		'import/no-cycle': 2,
 	},
 };


### PR DESCRIPTION
## What does this change?

Prevents circular dependencies. See https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md.

## Why?

Circular dependencies are... painful.

We've just spent a few hours mobbing on a `TypeError: Cannot read property of undefined` error when adding `@guardian/cdk` to the TypeRighter app.

The solution was to ensure imports are added in a specific order and the root cause of this is some circular dependencies within `@guardian/cdk`.

Adding this rule to the linter means we catch circular dependencies early and prevent the same from happening again.
