### PR TITLE
jsxBracketSameLine is deprecated

### DIFF
--- a/packages/prettier/index.js
+++ b/packages/prettier/index.js
@@ -1,7 +1,7 @@
 module.exports = {
 	arrowParens: 'always',
 	bracketSpacing: true,
-	jsxBracketSameLine: false,
+	bracketSameLine: false,
 	jsxSingleQuote: false,
 	printWidth: 80,
 	quoteProps: 'as-needed',


### PR DESCRIPTION
## What does this change?

`jsxBracketSameLine` > `bracketSameLine` in prettier config

## Why?

deprecated prop https://prettier.io/blog/2021/09/09/2.4.0.html