### PR TITLE
Use built in caching from setup-node action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: guardian/actions-setup-node@v2.4.0
-      - uses: bahmutov/npm-install@v1
+        with:
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
       - run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: guardian/actions-setup-node@v2.4.0
+      - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
## What is the purpose of this change?

This change swaps dependency caching to use the [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) rather than [bahmutov/npm-install](https://github.com/bahmutov/npm-install).

## What does this change?

-   Add configuration parameter to [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) enable caching
-   Change install step to `yarn install --frozen-lockfile` to ensure repeatable runs
