### PR TITLE
feat: Prevent “dangling” returns and force braces

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -16,8 +16,8 @@ module.exports = {
 	plugins: ['eslint-comments'],
 	rules: {
 		// prevent dangling returns without braces
-		"curly": ["error", "multi-line"],
-		
+		curly: ['error', 'multi-line'],
+
 		// require a `eslint-enable` comment for every `eslint-disable` comment
 		'eslint-comments/disable-enable-pair': [2, { allowWholeFile: true }],
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -15,6 +15,9 @@ module.exports = {
 	],
 	plugins: ['eslint-comments'],
 	rules: {
+		// prevent dangling returns without braces
+		"curly": ["error", "multi-line"],
+		
 		// require a `eslint-enable` comment for every `eslint-disable` comment
 		'eslint-comments/disable-enable-pair': [2, { allowWholeFile: true }],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,14 +39,14 @@
     strip-json-comments "^3.1.1"
 
 "@guardian/eslint-config-typescript@file:packages/eslint-config-typescript":
-  version "0.7.0"
+  version "0.6.1"
   dependencies:
-    "@guardian/eslint-config" "^0.7.0"
+    "@guardian/eslint-config" "^0.6.1"
     "@typescript-eslint/eslint-plugin" "4.29.2"
     "@typescript-eslint/parser" "4.29.2"
 
-"@guardian/eslint-config@^0.7.0", "@guardian/eslint-config@file:packages/eslint-config":
-  version "0.7.0"
+"@guardian/eslint-config@^0.6.1", "@guardian/eslint-config@file:packages/eslint-config":
+  version "0.6.1"
   dependencies:
     eslint-config-prettier "8.3.0"
     eslint-plugin-eslint-comments "3.2.0"
@@ -54,7 +54,7 @@
     eslint-plugin-prettier "3.4.0"
 
 "@guardian/prettier@file:packages/prettier":
-  version "0.7.0"
+  version "0.6.0"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,14 +39,14 @@
     strip-json-comments "^3.1.1"
 
 "@guardian/eslint-config-typescript@file:packages/eslint-config-typescript":
-  version "0.6.1"
+  version "0.7.0"
   dependencies:
-    "@guardian/eslint-config" "^0.6.1"
+    "@guardian/eslint-config" "^0.7.0"
     "@typescript-eslint/eslint-plugin" "4.29.2"
     "@typescript-eslint/parser" "4.29.2"
 
-"@guardian/eslint-config@^0.6.1", "@guardian/eslint-config@file:packages/eslint-config":
-  version "0.6.1"
+"@guardian/eslint-config@^0.7.0", "@guardian/eslint-config@file:packages/eslint-config":
+  version "0.7.0"
   dependencies:
     eslint-config-prettier "8.3.0"
     eslint-plugin-eslint-comments "3.2.0"
@@ -54,7 +54,7 @@
     eslint-plugin-prettier "3.4.0"
 
 "@guardian/prettier@file:packages/prettier":
-  version "0.6.0"
+  version "0.7.0"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
## What does this change?

If a block contains only one statement, but it’s on a different line than the block start, force curly braces.

Turns:
```ts
if(
 conditionOne() &&
 conditionTwo() && 
 conditionThree()
)
  return true;
```

Into

```ts
if(
 conditionOne() &&
 conditionTwo() && 
 conditionThree()
) {
  return true;
}
```

## Why?

This can easily introduce errors when refactoring code. Thanks @arelra for the suggestion