### PR TITLE
Access browser usage stats correctly

### DIFF
--- a/.changeset/many-radios-raise.md
+++ b/.changeset/many-radios-raise.md
@@ -1,0 +1,5 @@
+---
+'@guardian/browserslist-config': patch
+---
+
+fix an issue with accessing stats from consuming projects

--- a/packages/browserslist-config/browserslist.js
+++ b/packages/browserslist-config/browserslist.js
@@ -1,1 +1,1 @@
-module.exports = ['supports es6-module and >= 0.01% in my stats'];
+module.exports = ['supports es6-module and >= 0.01% in @guardian/browserslist-config stats'];

--- a/packages/browserslist-config/browserslist.js
+++ b/packages/browserslist-config/browserslist.js
@@ -1,1 +1,3 @@
-module.exports = ['supports es6-module and >= 0.01% in @guardian/browserslist-config stats'];
+module.exports = [
+	'supports es6-module and >= 0.01% in @guardian/browserslist-config stats'
+];

--- a/packages/browserslist-config/browserslist.js
+++ b/packages/browserslist-config/browserslist.js
@@ -1,3 +1,3 @@
 module.exports = [
-	'supports es6-module and >= 0.01% in @guardian/browserslist-config stats'
+	'supports es6-module and >= 0.01% in @guardian/browserslist-config stats',
 ];


### PR DESCRIPTION
## What does this change?

Changes 'in my stats' to 'in @guardian/browserslist-config stats'.

## Why?

This enables dependent projects to access the stats file; 'in my stats' seems to cause browserslist to look for a file in the root directory. Cf. https://github.com/browserslist/browserslist#shareable-configs
