### PR TITLE
add types to prettier config

### DIFF
--- a/.changeset/hip-lies-shout.md
+++ b/.changeset/hip-lies-shout.md
@@ -1,0 +1,5 @@
+---
+'@guardian/prettier': minor
+---
+
+Add types to prettier config

--- a/packages/prettier/index.js
+++ b/packages/prettier/index.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('prettier').Options}
+ */
 module.exports = {
 	arrowParens: 'always',
 	bracketSpacing: true,


### PR DESCRIPTION
## What does this change?
add types to the prettier config
## Why?
so you can use it more easily with the prettier API in `.ts` files